### PR TITLE
fix(test): resolve E2E test incompatibility with OAuth RBAC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
       - name: E2E Tests (Node 20 only)
         if: matrix.node-version == '20.x'
         timeout-minutes: 8
+        env:
+          VITE_ENABLE_TESTING: true
         run: |
           # Set up process tracking and cleanup
           set -e
@@ -147,9 +149,9 @@ jobs:
           backend/.venv/bin/python -m uvicorn app.main:app --app-dir backend --host 0.0.0.0 --port 8000 &
           BACKEND_PID=$!
 
-          # Start frontend
-          echo "🌐 Starting frontend server..."
-          yarn vite &
+          # Start frontend with testing environment enabled
+          echo "🌐 Starting frontend server with testing environment..."
+          VITE_ENABLE_TESTING=true yarn vite &
           FRONTEND_PID=$!
 
           # Wait for both services to be ready with reduced timeout

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
     timeout: 180 * 1000, // Full-stack startup requires more time
     env: {
       MODE: 'test',
+      VITE_ENABLE_TESTING: 'true', // Enable test login buttons for E2E tests
     },
   },
 });


### PR DESCRIPTION
## Summary
- Configure `VITE_ENABLE_TESTING=true` in CI environment for E2E tests
- Update `playwright.config.ts` to enable test login buttons in local development  
- Fix `audit-logs.spec.ts` test failures caused by conditional rendering after OAuth RBAC implementation

## Problem Analysis
After T-02 OAuth RBAC implementation, E2E tests were failing because test login buttons (`test-login-admin` and `test-login-editor`) are conditionally rendered only when:
- `getEnvVar('DEV')` is true, OR
- `getEnvVar('VITE_ENABLE_TESTING') === 'true'`

In CI environments, neither condition was met, causing test failures.

## Solution
1. **CI Configuration**: Added `VITE_ENABLE_TESTING=true` environment variable to E2E test step in `.github/workflows/ci.yml`
2. **Local Development**: Updated `playwright.config.ts` to include `VITE_ENABLE_TESTING=true` in webServer environment for consistency
3. **Full-Stack Testing**: Ensured both frontend and backend receive the proper environment configuration

## Test Coverage
- ✅ TypeScript validation passes
- ✅ ESLint validation passes  
- ✅ Prettier formatting passes
- ✅ Application builds successfully
- ✅ Quality gates pass according to CONTRIBUTING.md

## Files Changed
- `.github/workflows/ci.yml` - Added `VITE_ENABLE_TESTING=true` to E2E test environment
- `playwright.config.ts` - Added test environment variable to webServer config

## Testing Strategy
The fix ensures that test login buttons are available in both CI and local development environments without compromising production security, as the variable is only set in test contexts.

🤖 Generated with [Claude Code](https://claude.ai/code)